### PR TITLE
OS command injection 방지를 위한 조치

### DIFF
--- a/ndtp-admin/src/main/java/ndtp/config/PropertiesConfig.java
+++ b/ndtp-admin/src/main/java/ndtp/config/PropertiesConfig.java
@@ -66,5 +66,6 @@ public class PropertiesConfig {
     private String dataObjectAttributeUploadDir;
     
     private String guideDataServiceDir;
-
+    
+    private String ogr2ogrEnviromentPath; 
 }

--- a/ndtp-admin/src/main/java/ndtp/geospatial/Ogr2OgrExecute.java
+++ b/ndtp-admin/src/main/java/ndtp/geospatial/Ogr2OgrExecute.java
@@ -21,8 +21,9 @@ public class Ogr2OgrExecute {
     private String layerTargetCoordinate;
     private String exportPath;
     private String sql;
+    private String environmentPath;
 
-    public Ogr2OgrExecute(String osType, String driver, String shapeFile, String shapeEncoding, String tableName, String updateOption, String layerSourceCoordinate, String layerTargetCoordinate) {
+    public Ogr2OgrExecute(String osType, String driver, String shapeFile, String shapeEncoding, String tableName, String updateOption, String layerSourceCoordinate, String layerTargetCoordinate, String environmentPath) {
         this.osType = osType;
         this.driver = driver;
         this.shapeFile = shapeFile;
@@ -31,6 +32,7 @@ public class Ogr2OgrExecute {
         this.updateOption = updateOption;
         this.layerSourceCoordinate = layerSourceCoordinate;
         this.layerTargetCoordinate = layerTargetCoordinate;
+        this.environmentPath = environmentPath;
     }
 
     public Ogr2OgrExecute(String osType, String driver, String shapeEncoding, String exportPath, String sql, String layerSourceCoordinate, String layerTargetCoordinate) {
@@ -79,8 +81,7 @@ public class Ogr2OgrExecute {
         command.add("-nln");
         command.add(this.tableName);
         log.info(" >>>>>> insert command = {}", command.toString());
-
-        ProcessBuilderSupport.execute(command);
+        ProcessBuilderSupport.execute(command, environmentPath);
     }
 
     public void export() throws Exception {
@@ -107,6 +108,6 @@ public class Ogr2OgrExecute {
 
         log.info(" >>>>>> export command = {}", command.toString());
 
-        ProcessBuilderSupport.execute(command);
+        ProcessBuilderSupport.execute(command, environmentPath);
     }
 }

--- a/ndtp-admin/src/main/java/ndtp/geospatial/Ogr2OgrRunnable.java
+++ b/ndtp-admin/src/main/java/ndtp/geospatial/Ogr2OgrRunnable.java
@@ -21,13 +21,15 @@ public class Ogr2OgrRunnable implements Runnable {
 	private String tableName;
 	// 새로 생성할건지, update 할건지, append 인지..... update가 upsert를 지원하는지 모르겠다.
 	private String updateOption;
+	private String environmentPath;
 	
-	public Ogr2OgrRunnable(String osType, String driver, String shapeFile, String tableName, String updateOption) {
+	public Ogr2OgrRunnable(String osType, String driver, String shapeFile, String tableName, String updateOption, String environmentPath) {
 		this.osType = osType;
 		this.driver = driver;
 		this.shapeFile = shapeFile;
 		this.tableName = tableName;
 		this.updateOption = updateOption;
+		this.environmentPath = environmentPath;
 	}
 	
 	@Override
@@ -66,7 +68,7 @@ public class Ogr2OgrRunnable implements Runnable {
 		log.info(" >>>>>> command = {}", command.toString());
 		
 		try {
-			ProcessBuilderSupport.execute(command);
+			ProcessBuilderSupport.execute(command, environmentPath);
 		} catch (Exception e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();

--- a/ndtp-admin/src/main/java/ndtp/service/impl/LayerServiceImpl.java
+++ b/ndtp-admin/src/main/java/ndtp/service/impl/LayerServiceImpl.java
@@ -298,8 +298,8 @@ public class LayerServiceImpl implements LayerService {
         String layerTargetCoordinate = geoPolicy.getLayerTargetCoordinate();
 //		ShapeFileParser shapeFileParser = new ShapeFileParser();
 //		shapeFileParser.parse(shapeFileName);
-
-        Ogr2OgrExecute ogr2OgrExecute = new Ogr2OgrExecute(osType, driver, shapeFileName, shapeEncoding, layer.getLayerKey(), updateOption, layerSourceCoordinate, layerTargetCoordinate);
+        String enviromentPath = propertiesConfig.getOgr2ogrEnviromentPath();
+        Ogr2OgrExecute ogr2OgrExecute = new Ogr2OgrExecute(osType, driver, shapeFileName, shapeEncoding, layer.getLayerKey(), updateOption, layerSourceCoordinate, layerTargetCoordinate, enviromentPath);
         ogr2OgrExecute.insert();
     }
     

--- a/ndtp-admin/src/main/java/ndtp/support/ProcessBuilderSupport.java
+++ b/ndtp-admin/src/main/java/ndtp/support/ProcessBuilderSupport.java
@@ -1,12 +1,18 @@
 package ndtp.support;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.io.FilenameUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import lombok.extern.slf4j.Slf4j;
+import ndtp.config.PropertiesConfig;
 
 /**
  * @author Cheon JeongDae
@@ -15,12 +21,22 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class ProcessBuilderSupport {
 
-	public static void execute(List<String> command) {
+	public static void execute(List<String> command, String path) {
 		
 		log.info("---------- start ----------");
 		log.info("@@@@@@@ command = {}", command);
 		
 		ProcessBuilder processBuilder = new ProcessBuilder(command);
+		
+		// Bug Fix : Potential Command Injection
+		// 참고 : https://cheatsheetseries.owasp.org/cheatsheets/OS_Command_Injection_Defense_Cheat_Sheet.html
+		Map<String, String> env = processBuilder.environment();
+		
+		log.info("@@@@@@@ path = {}", env.get(path));
+		if (env.get(path) != null && !env.get(path).isEmpty()) {
+			processBuilder.directory(new File(FilenameUtils.getName(env.get(path))));
+		}
+		
 		processBuilder.redirectErrorStream(true);
 		InputStream inputStream = null;
         InputStreamReader inputStreamReader = null;

--- a/ndtp-admin/src/main/resources/ndtp.properties
+++ b/ndtp-admin/src/main/resources/ndtp.properties
@@ -39,3 +39,5 @@ ndtp.layer-export-dir=C:\\data\\ndtp\\ndtp-admin\\export\\temp\\
 
 #\uAC00\uC774\uB4DC \uB370\uC774\uD130 \uACBD\uB85C
 ndtp.guide-data-service-dir=C:\\data\\mago3d\\guide\\f4d\\
+
+ndtp.ogr2ogr-enviroment-path=QGIS_HOME


### PR DESCRIPTION
OS command line을 직접적으로 호출하는 것을 예방하기 위해서
command line을 호출하는 directory를 지정하도록 소스를 수정하였습니다.
[https://cheatsheetseries.owasp.org/cheatsheets/OS_Command_Injection_Defense_Cheat_Sheet.html](url)

QGIS_HOME이라는 환경변수에 ogr2ogr을 호출할 수 있는 경로가 지정되어 있으면 
그 경로에서 호출하도록 소스를 변경하였습니다. (없으면 기존과 동일하게 수행됨)

환경 변수의 이름은 ndtp.properties파일에 ndtp.ogr2ogr-enviroment-path 항목에서 
정의할 수 있도록 수정해 두었습니다.

소스 내용 검토해 보시고 적용할지 말지 확인해 주세요.